### PR TITLE
feat(deleter): automatic tear down - EUBFR-83

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,27 @@ First, make sure you have deployed the services. Then:
 yarn deploy-demo
 ```
 
+## Remove the services and the demo
+
+You can remove all the services with the following command:
+
+```sh
+yarn run delete
+```
+
+If you want to delete the demos, you can run:
+
+```sh
+yarn run delete-demo
+```
+
+Or, if you want to target a specific producer demo:
+
+```sh
+EUBFR_USERNAME=budg yarn run delete-demo
+ ```
+
+
 ## Notes
 
 -   Deploy `services/storage` first.

--- a/demo/dashboard/client/serverless.yml
+++ b/demo/dashboard/client/serverless.yml
@@ -1,12 +1,14 @@
-service: demo-dash-client-${opt:username}
+service: demo-dash-client-${self:custom.EUBFR_USERNAME}
 
 plugins:
   - serverless-finch
 
 custom:
   client:
-    bucketName: eubfr-${self:provider.stage}-demo-dashboard-client-${opt:username}
+    bucketName: eubfr-${self:provider.stage}-demo-dashboard-client-${self:custom.EUBFR_USERNAME}
   eubfrEnvironment: ${opt:eubfr_env, file(../../../config.json):eubfr_env, env:EUBFR_ENV, 'dev'}
+  # EUBFR_USERNAME comes from cli parameter, but for spawn() and similar, it's from env var.
+  EUBFR_USERNAME: ${opt:username, file(../../../config.json):username, env:EUBFR_USERNAME, ''}
 
 provider:
   name: aws

--- a/demo/dashboard/server/serverless.yml
+++ b/demo/dashboard/server/serverless.yml
@@ -1,4 +1,4 @@
-service: demo-dash-server-${opt:username}
+service: demo-dash-server-${self:custom.EUBFR_USERNAME}
 
 plugins:
   - serverless-stack-output
@@ -8,8 +8,10 @@ plugins:
 custom:
   webpackIncludeModules: true
   eubfrEnvironment: ${opt:eubfr_env, file(../../../config.json):eubfr_env, env:EUBFR_ENV, 'dev'}
-  PRODUCER_KEY_ID: ${opt:PRODUCER_KEY_ID, file(../../../config.json):demo.${opt:username}.AWS_ACCESS_KEY_ID, env:PRODUCER_KEY_ID, ''}
-  PRODUCER_SECRET_ACCESS_KEY: ${opt:PRODUCER_SECRET_ACCESS_KEY, file(../../../config.json):demo.${opt:username}.AWS_SECRET_ACCESS_KEY, env:PRODUCER_SECRET_ACCESS_KEY, ''}
+  # EUBFR_USERNAME comes from cli parameter, but for spawn() and similar, it's from env var.
+  EUBFR_USERNAME: ${opt:username, file(../../../config.json):username, env:EUBFR_USERNAME, ''}
+  PRODUCER_KEY_ID: ${opt:PRODUCER_KEY_ID, file(../../../config.json):demo.${self:custom.EUBFR_USERNAME}.AWS_ACCESS_KEY_ID, env:PRODUCER_KEY_ID, ''}
+  PRODUCER_SECRET_ACCESS_KEY: ${opt:PRODUCER_SECRET_ACCESS_KEY, file(../../../config.json):demo.${self:custom.EUBFR_USERNAME}.AWS_SECRET_ACCESS_KEY, env:PRODUCER_SECRET_ACCESS_KEY, ''}
   SIGNED_UPLOADS_API: ${opt:SIGNED_UPLOADS_API, file(../../../services/storage/signed-uploads/.serverless/stack-output.json):ServiceEndpoint, env:SIGNED_UPLOADS_API, ''}
   DELETER_API: ${opt:DELETER_API, file(../../../services/storage/deleter/.serverless/stack-output.json):ServiceEndpoint, env:DELETER_API, ''}
   META_INDEX_API: ${opt:META_INDEX_API, file(../../../services/storage/meta-index/.serverless/stack-output.json):ServiceEndpoint, env:META_INDEX_API, ''}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
     "bootstrap": "lerna bootstrap",
     "deploy": "./scripts/deploy.sh",
     "deploy-demo": "./scripts/deploy-demo.sh",
+    "delete": "node ./scripts/delete.js",
+    "delete-demo": "./scripts/delete-demo.js",
     "flow": "flow",
     "lint": "eslint .",
     "precommit": "lint-staged",

--- a/scripts/delete-demo.js
+++ b/scripts/delete-demo.js
@@ -2,7 +2,8 @@
 
 // Dependencies
 const deleteServerlessService = require('./utils/deleteServerlessService');
-const config = require('../config');
+
+const config = require('../config'); // eslint-disable-line import/no-unresolved
 
 const usernames = Object.keys(config.demo);
 

--- a/scripts/delete-demo.js
+++ b/scripts/delete-demo.js
@@ -5,14 +5,22 @@ const deleteServerlessService = require('./utils/deleteServerlessService');
 
 const config = require('../config'); // eslint-disable-line import/no-unresolved
 
-const usernames = Object.keys(config.demo);
+let usernames = Object.keys(config.demo);
 
-const services = [`demo-dashboard-server`];
-
-if (!process.env.EUBFR_USERNAME) {
-  console.error(`EUBFR_USERNAME environment variable is required.`);
-  console.log(`Please pass one of the following: ${usernames}`);
-  console.log(`For example: "EUBFR_USERNAME=${usernames[0]} yarn delete-demo"`);
-} else {
-  services.forEach(deleteServerlessService);
+if (process.env.EUBFR_USERNAME) {
+  usernames = usernames.filter(
+    username => username === process.env.EUBFR_USERNAME
+  );
 }
+
+// Remove dashboards
+usernames.forEach(username => {
+  deleteServerlessService('demo-dashboard-client', {
+    isClient: true,
+    username,
+  });
+  deleteServerlessService('demo-dashboard-server', { username });
+});
+
+// Remove website
+deleteServerlessService('demo-website', { isClient: true });

--- a/scripts/delete-demo.js
+++ b/scripts/delete-demo.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+// Dependencies
+const deleteServerlessService = require('./utils/deleteServerlessService');
+const config = require('../config');
+
+const usernames = Object.keys(config.demo);
+
+const services = [`demo-dashboard-server`];
+
+if (!process.env.EUBFR_USERNAME) {
+  console.error(`EUBFR_USERNAME environment variable is required.`);
+  console.log(`Please pass one of the following: ${usernames}`);
+  console.log(`For example: "EUBFR_USERNAME=${usernames[0]} yarn delete-demo"`);
+} else {
+  services.forEach(deleteServerlessService);
+}

--- a/scripts/delete.js
+++ b/scripts/delete.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+// Dependencies
+const { exec } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+
+const sh = promisify(exec);
+
+// Get config
+const config = require(`../config.json`);
+
+// Helpers
+const resolveSymbolicLink = filePath => {
+  const lstat = fs.lstatSync(filePath);
+  return lstat.isSymbolicLink()
+    ? path.resolve(path.dirname(filePath), fs.readlinkSync(filePath))
+    : false;
+};
+
+// Order is important!
+const services = [
+  `storage-objects`,
+  `ingestion-etl-results`,
+  `storage-signed-uploads`,
+  `storage-deleter`,
+  `storage-meta-index`,
+  `harmonized-storage`,
+  `ingestion-manager`,
+  `ingestion-cleaner`,
+  `ingestion-etl-budg-csv`,
+  `ingestion-etl-budg-xls`,
+  `ingestion-etl-inforegio-json`,
+  `elasticsearch`,
+  `value-store-projects`,
+];
+
+services.forEach(service => {
+  sh(
+    `./node_modules/.bin/sls remove --stage ${config.stage} --region ${config.region}`,
+    {
+      cwd: resolveSymbolicLink(`node_modules/@eubfr/${service}`),
+    }
+  )
+    .then(console.log)
+    .catch(console.error);
+});

--- a/scripts/delete.js
+++ b/scripts/delete.js
@@ -1,14 +1,8 @@
 #!/usr/bin/env node
 
 // Dependencies
-const { spawn } = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const deleteServerlessService = require('./utils/deleteServerlessService');
 
-// Get config
-const config = require(`../config.json`);
-
-// Easier to edit in the beginning of the file
 const services = [
   `storage-objects`,
   `ingestion-etl-results`,
@@ -25,36 +19,4 @@ const services = [
   `value-store-projects`,
 ];
 
-// Helpers
-const resolveSymbolicLink = filePath => {
-  const lstat = fs.lstatSync(filePath);
-  return lstat.isSymbolicLink()
-    ? path.resolve(path.dirname(filePath), fs.readlinkSync(filePath))
-    : false;
-};
-
-const deleteServerlessService = service => {
-  console.log(`Start deletion of ${service}`);
-  console.time(service);
-
-  const operation = spawn(
-    `./node_modules/.bin/sls`,
-    ['remove', `--stage ${config.stage}`, `--region ${config.region}`],
-    {
-      cwd: resolveSymbolicLink(`node_modules/@eubfr/${service}`),
-    }
-  );
-
-  operation.stdout.on('data', data => {
-    console.log('\x1b[36m', `${data}`, '\x1b[0m');
-  });
-
-  operation.stderr.on('data', data => {
-    console.log('\x1b[31m', `${data}`, '\x1b[31m');
-  });
-
-  operation.on('close', () => console.timeEnd(service));
-};
-
-// And run the deletion procedure
 services.forEach(deleteServerlessService);

--- a/scripts/utils/deleteServerlessService.js
+++ b/scripts/utils/deleteServerlessService.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 // Get config
-const config = require(`../../config.json`);
+const config = require(`../../config.json`); // eslint-disable-line import/no-unresolved
 
 // Helpers
 const resolveSymbolicLink = filePath => {

--- a/scripts/utils/deleteServerlessService.js
+++ b/scripts/utils/deleteServerlessService.js
@@ -1,0 +1,43 @@
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// Get config
+const config = require(`../../config.json`);
+
+// Helpers
+const resolveSymbolicLink = filePath => {
+  const lstat = fs.lstatSync(filePath);
+  return lstat.isSymbolicLink()
+    ? path.resolve(path.dirname(filePath), fs.readlinkSync(filePath))
+    : false;
+};
+
+module.exports = service => {
+  console.log(`Start deletion of ${service}`);
+  console.time(service);
+
+  const operation = spawn(
+    `./node_modules/.bin/sls`,
+    ['remove', `--stage ${config.stage}`, `--region ${config.region}`],
+    {
+      cwd: resolveSymbolicLink(`node_modules/@eubfr/${service}`),
+      // This is a helper for serverless.yml variables as an alternative to options
+      env: {
+        EUBFR_USERNAME: process.env.EUBFR_USERNAME
+          ? process.env.EUBFR_USERNAME
+          : '',
+      },
+    }
+  );
+
+  operation.stdout.on('data', data => {
+    console.log('\x1b[36m', `${data}`, '\x1b[0m');
+  });
+
+  operation.stderr.on('data', data => {
+    console.log('\x1b[31m', `${data}`, '\x1b[31m');
+  });
+
+  operation.on('close', () => console.timeEnd(service));
+};

--- a/scripts/utils/deleteServerlessService.js
+++ b/scripts/utils/deleteServerlessService.js
@@ -13,10 +13,7 @@ const resolveSymbolicLink = filePath => {
     : false;
 };
 
-module.exports = (
-  service,
-  { isClient, username } = { isClient: false, username: '' }
-) => {
+module.exports = (service, { isClient = false, username = '' }) => {
   const serviceName = `${service}${username ? `-${username}` : ''}`;
   console.log(`Start deletion of ${serviceName}`);
   console.time(serviceName);

--- a/services/harmonized-storage/package.json
+++ b/services/harmonized-storage/package.json
@@ -7,5 +7,8 @@
   },
   "devDependencies": {
     "serverless": "1.23.0"
+  },
+  "dependencies": {
+    "serverless-s3-remover": "^0.4.0"
   }
 }

--- a/services/harmonized-storage/package.json
+++ b/services/harmonized-storage/package.json
@@ -6,9 +6,7 @@
     "deploy": "sls deploy -v"
   },
   "devDependencies": {
-    "serverless": "1.23.0"
-  },
-  "dependencies": {
+    "serverless": "1.23.0",
     "serverless-s3-remover": "^0.4.0"
   }
 }

--- a/services/harmonized-storage/serverless.yml
+++ b/services/harmonized-storage/serverless.yml
@@ -1,8 +1,14 @@
 service: harmonized-storage
 
+plugins:
+  - serverless-s3-remover
+
 custom:
   eubfrEnvironment: ${opt:eubfr_env, file(../../config.json):eubfr_env, env:EUBFR_ENV, 'dev'}
   bucketName: eubfr-${self:provider.stage}-harmonized
+  remover:
+     buckets:
+       - ${self:custom.bucketName}
 
 provider:
   name: aws

--- a/services/storage/objects/package.json
+++ b/services/storage/objects/package.json
@@ -7,5 +7,8 @@
   },
   "devDependencies": {
     "serverless": "1.23.0"
+  },
+  "dependencies": {
+    "serverless-s3-remover": "^0.4.0"
   }
 }

--- a/services/storage/objects/package.json
+++ b/services/storage/objects/package.json
@@ -6,9 +6,7 @@
     "deploy": "sls deploy -v"
   },
   "devDependencies": {
-    "serverless": "1.23.0"
-  },
-  "dependencies": {
+    "serverless": "1.23.0",
     "serverless-s3-remover": "^0.4.0"
   }
 }

--- a/services/storage/objects/serverless.yml
+++ b/services/storage/objects/serverless.yml
@@ -1,7 +1,13 @@
 service: storage-objects
 
+plugins:
+  - serverless-s3-remover
+
 custom:
   eubfrEnvironment: ${opt:eubfr_env, file(../../../config.json):eubfr_env, env:EUBFR_ENV, 'dev'}
+  remover:
+     buckets:
+       - eubfr-${self:provider.stage}
 
 provider:
   name: aws

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,6 +453,14 @@ async@^2.0.0, async@^2.1.2, async@^2.1.4, async@^2.4.1:
   dependencies:
     lodash "^4.14.0"
 
+async@~0.9.0:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+
+async@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1871,7 +1879,11 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
-colors@~1.1.2:
+colors@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+
+colors@^1.1.2, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -2430,6 +2442,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+cycle@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
+
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -2538,6 +2554,10 @@ dedent@^0.7.0:
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+
+deep-equal@~0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-0.2.2.tgz#84b745896f34c684e98f2ce0e42abaf43bba017d"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -3427,6 +3447,10 @@ extract-text-webpack-plugin@3.0.0:
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+
+eyes@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
 
 fast-deep-equal@^1.0.0:
   version "1.0.0"
@@ -4352,6 +4376,10 @@ husky@0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
+i@0.3.x:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/i/-/i-0.3.6.tgz#d96c92732076f072711b6b10fd7d4f65ad8ee23d"
+
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -4761,7 +4789,7 @@ isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
-isstream@~0.1.2:
+isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
@@ -6067,7 +6095,7 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -6100,7 +6128,7 @@ mute-stream@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
 
-mute-stream@0.0.7:
+mute-stream@0.0.7, mute-stream@~0.0.4:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
@@ -6121,6 +6149,10 @@ ncname@1.0.x:
   resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"
   dependencies:
     xml-char-classes "^1.0.0"
+
+ncp@1.0.x:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-1.0.1.tgz#d15367e5cb87432ba117d2bf80fdf45aecfb4246"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -6688,6 +6720,14 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkginfo@0.3.x:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
+
+pkginfo@0.x.x:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
+
 pluralize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
@@ -7061,6 +7101,17 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prompt@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prompt/-/prompt-1.0.0.tgz#8e57123c396ab988897fb327fd3aedc3e735e4fe"
+  dependencies:
+    colors "^1.1.2"
+    pkginfo "0.x.x"
+    read "1.0.x"
+    revalidator "0.1.x"
+    utile "0.3.x"
+    winston "2.1.x"
+
 prop-types@15.6.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
@@ -7370,6 +7421,12 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+read@1.0.x:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
+  dependencies:
+    mute-stream "~0.0.4"
+
 readable-stream@1.0, readable-stream@~1.0.2:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
@@ -7649,13 +7706,17 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
+revalidator@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/revalidator/-/revalidator-0.1.8.tgz#fece61bfa0c1b52a206bd6b18198184bdd523a3b"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
+rimraf@2, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -7849,6 +7910,13 @@ serverless-offline@3.16.0:
     jsonwebtoken "^7.4.3"
     lodash "^4.17.4"
     velocityjs "^0.9.3"
+
+serverless-s3-remover@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/serverless-s3-remover/-/serverless-s3-remover-0.4.0.tgz#a02b2a7c734986fd5d63c137f0ab9aff0b599505"
+  dependencies:
+    chalk "^2.1.0"
+    prompt "^1.0.0"
 
 serverless-stack-output@0.2.0:
   version "0.2.0"
@@ -8180,6 +8248,10 @@ sshpk@^1.7.0:
 stack-trace@0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
 
 staged-git-files@0.0.4:
   version "0.0.4"
@@ -8896,6 +8968,17 @@ utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
 
+utile@0.3.x:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/utile/-/utile-0.3.0.tgz#1352c340eb820e4d8ddba039a4fbfaa32ed4ef3a"
+  dependencies:
+    async "~0.9.0"
+    deep-equal "~0.2.1"
+    i "0.3.x"
+    mkdirp "0.x.x"
+    ncp "1.0.x"
+    rimraf "2.x.x"
+
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
@@ -9215,6 +9298,18 @@ widest-line@^1.0.0:
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+
+winston@2.1.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.1.1.tgz#3c9349d196207fd1bdff9d4bc43ef72510e3a12e"
+  dependencies:
+    async "~1.0.0"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    pkginfo "0.3.x"
+    stack-trace "0.0.x"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Easier way to delete a staging/workspace for a given user. Useful in the end of the day or the end of the week.

Please run `yarn` to get new dependencies before running the tests.

2 new commands:
- `yarn run delete` to get rid of all `services`. As many ops are run in parallel to the AWS API, you might want to re-run the script twice if a longer operation, such as `elasticsearch` does not go through.
- `EUBFR_USERNAME=budg yarn run delete-demo` or similar to delete `server` apps for demos.

Notes:
- client apps are not delete-able in the same approach, because they are not CF stacks, and `serverless remove` does not have control over assets created by `serverless-finch`.
- dynamodb tables are preserved as usual