### PR TITLE
fix(etl): investigate possible issue budg etl - EUBFR-116

### DIFF
--- a/services/ingestion/etl/budg/xls/src/lib/transform.js
+++ b/services/ingestion/etl/budg/xls/src/lib/transform.js
@@ -47,7 +47,7 @@ export default (record: Object): Project => {
 
   const partnerArray = [];
   for (let i = 0; i < partnerKeys.length; i += 1) {
-    if (record[`Partner ${i + 1} name`] != null) {
+    if (record[`Partner ${i + 1} name`]) {
       partnerArray.push({
         name: record[`Partner ${i + 1} name`],
         type: record[`Partner ${i + 1} organisation type`],


### PR DESCRIPTION
On the partners array creation we were checking for a `null` value but instead we should bypass all _falsy_ values. The values will most likely only be typeof: `string`