### PR TITLE
feat(geo-point): add centroid to records - EUBFR-130

### DIFF
--- a/resources/elasticsearch/mappings/project.js
+++ b/resources/elasticsearch/mappings/project.js
@@ -55,6 +55,9 @@ module.exports = () => ({
       },
       project_locations: {
         properties: {
+          centroid: {
+            type: 'geo_point',
+          },
           location: {
             type: 'geo_shape',
           },

--- a/services/ingestion/etl/agri/csv/src/lib/transform.js
+++ b/services/ingestion/etl/agri/csv/src/lib/transform.js
@@ -87,7 +87,7 @@ export default (record: Object): Project => {
         centroid: hasCoordinates
           ? {
               lat: parseFloat(latArray[index]) || 0,
-              long: parseFloat(longArray[index]) || 0,
+              lon: parseFloat(longArray[index]) || 0,
             }
           : null,
         location: hasCoordinates

--- a/services/ingestion/etl/agri/csv/test/unit/lib/__snapshots__/transform.spec.js.snap
+++ b/services/ingestion/etl/agri/csv/test/unit/lib/__snapshots__/transform.spec.js.snap
@@ -154,7 +154,7 @@ Object {
       "address": "",
       "centroid": Object {
         "lat": 48.211312,
-        "long": 16.367315,
+        "lon": 16.367315,
       },
       "country_code": "AT",
       "location": Object {
@@ -173,7 +173,7 @@ Object {
       "address": "",
       "centroid": Object {
         "lat": 45.803508,
-        "long": 16.017459,
+        "lon": 16.017459,
       },
       "country_code": "HR",
       "location": Object {
@@ -192,7 +192,7 @@ Object {
       "address": "",
       "centroid": Object {
         "lat": 49.449922,
-        "long": 11.10347,
+        "lon": 11.10347,
       },
       "country_code": "DE",
       "location": Object {
@@ -211,7 +211,7 @@ Object {
       "address": "",
       "centroid": Object {
         "lat": 48.143047,
-        "long": 17.12426,
+        "lon": 17.12426,
       },
       "country_code": "SK",
       "location": Object {
@@ -230,7 +230,7 @@ Object {
       "address": "",
       "centroid": Object {
         "lat": 46.048183,
-        "long": 14.501456,
+        "lon": 14.501456,
       },
       "country_code": "SI",
       "location": Object {
@@ -279,7 +279,7 @@ Object {
   "address": "",
   "centroid": Object {
     "lat": 48.211312,
-    "long": 16.367315,
+    "lon": 16.367315,
   },
   "country_code": "AT",
   "location": Object {
@@ -344,7 +344,7 @@ Object {
       "address": "",
       "centroid": Object {
         "lat": 42.73806663,
-        "long": 23.40014509,
+        "lon": 23.40014509,
       },
       "country_code": "",
       "location": Object {

--- a/services/ingestion/etl/agri/csv/test/unit/lib/__snapshots__/transform.spec.js.snap
+++ b/services/ingestion/etl/agri/csv/test/unit/lib/__snapshots__/transform.spec.js.snap
@@ -152,6 +152,10 @@ Object {
   "project_locations": Array [
     Object {
       "address": "",
+      "centroid": Object {
+        "lat": 48.211312,
+        "long": 16.367315,
+      },
       "country_code": "AT",
       "location": Object {
         "coordinates": Array [
@@ -167,6 +171,10 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": Object {
+        "lat": 45.803508,
+        "long": 16.017459,
+      },
       "country_code": "HR",
       "location": Object {
         "coordinates": Array [
@@ -182,6 +190,10 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": Object {
+        "lat": 49.449922,
+        "long": 11.10347,
+      },
       "country_code": "DE",
       "location": Object {
         "coordinates": Array [
@@ -197,6 +209,10 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": Object {
+        "lat": 48.143047,
+        "long": 17.12426,
+      },
       "country_code": "SK",
       "location": Object {
         "coordinates": Array [
@@ -212,6 +228,10 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": Object {
+        "lat": 46.048183,
+        "long": 14.501456,
+      },
       "country_code": "SI",
       "location": Object {
         "coordinates": Array [
@@ -257,6 +277,10 @@ Object {
 exports[`DG AGRI CSV transformer Project location information is correctly mapped 1`] = `
 Object {
   "address": "",
+  "centroid": Object {
+    "lat": 48.211312,
+    "long": 16.367315,
+  },
   "country_code": "AT",
   "location": Object {
     "coordinates": Array [
@@ -305,41 +329,23 @@ Object {
     },
   },
   "call_year": "",
-  "coordinators": Array [
-    Object {
-      "address": "",
-      "country": "",
-      "email": "",
-      "name": "",
-      "phone": "",
-      "region": "",
-      "type": "",
-      "website": "",
-    },
-  ],
+  "coordinators": Array [],
   "description": "",
-  "ec_priorities": Array [
-    "",
-  ],
+  "ec_priorities": Array [],
   "media": Object {
     "cover_image": "",
     "video": "",
   },
-  "partners": Array [
-    Object {
-      "address": "",
-      "country": "",
-      "name": "",
-      "region": "",
-      "type": "",
-      "website": "",
-    },
-  ],
+  "partners": Array [],
   "programme_name": "",
   "project_id": "",
   "project_locations": Array [
     Object {
       "address": "",
+      "centroid": Object {
+        "lat": 42.73806663,
+        "long": 23.40014509,
+      },
       "country_code": "",
       "location": Object {
         "coordinates": Array [
@@ -355,12 +361,7 @@ Object {
     },
   ],
   "project_website": "",
-  "related_links": Array [
-    Object {
-      "label": "",
-      "url": "",
-    },
-  ],
+  "related_links": Array [],
   "results": Object {
     "available": "",
     "result": "",

--- a/services/ingestion/etl/budg/xls/src/lib/transform.js
+++ b/services/ingestion/etl/budg/xls/src/lib/transform.js
@@ -70,15 +70,15 @@ export default (record: Object): Project => {
   });
 
   const partnerArray = [];
-  for (let i = 0; i < partnerKeys.length; i += 1) {
-    if (record[`Partner ${i + 1} name`]) {
+  for (let i = 1; i <= partnerKeys.length; i += 1) {
+    if (record[`Partner ${i} name`]) {
       partnerArray.push({
-        name: record[`Partner ${i + 1} name`],
-        type: record[`Partner ${i + 1} organisation type`],
-        address: record[`Partner ${i + 1} address`],
-        region: record[`Partner ${i + 1} region`],
-        country: record[`Partner ${i + 1} country`],
-        website: record[`Partner ${i + 1} website`],
+        name: record[`Partner ${i} name`],
+        type: record[`Partner ${i} organisation type`],
+        address: record[`Partner ${i} address`],
+        region: record[`Partner ${i} region`],
+        country: record[`Partner ${i} country`],
+        website: record[`Partner ${i} website`],
       });
     }
   }
@@ -86,6 +86,7 @@ export default (record: Object): Project => {
   // Preprocess locations
   const locationArray = record['Participating countries']
     .split(',')
+    .filter(loc => loc)
     .map(country => ({
       country_code: country,
       region: '',
@@ -93,6 +94,7 @@ export default (record: Object): Project => {
       address: '',
       postal_code: '',
       town: '',
+      centroid: null,
       location: null,
     }));
 

--- a/services/ingestion/etl/budg/xls/test/unit/lib/__snapshots__/transform.spec.js.snap
+++ b/services/ingestion/etl/budg/xls/test/unit/lib/__snapshots__/transform.spec.js.snap
@@ -98,6 +98,7 @@ Object {
   "project_locations": Array [
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "NL",
       "location": null,
       "nuts2": "",
@@ -107,6 +108,7 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "ES",
       "location": null,
       "nuts2": "",
@@ -116,6 +118,7 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "IT",
       "location": null,
       "nuts2": "",
@@ -125,6 +128,7 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "BA",
       "location": null,
       "nuts2": "",
@@ -134,6 +138,7 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "PL",
       "location": null,
       "nuts2": "",
@@ -143,6 +148,7 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "UK",
       "location": null,
       "nuts2": "",
@@ -270,6 +276,7 @@ Object {
   "project_locations": Array [
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "NL",
       "location": null,
       "nuts2": "",
@@ -279,6 +286,7 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "ES",
       "location": null,
       "nuts2": "",
@@ -288,6 +296,7 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "IT",
       "location": null,
       "nuts2": "",
@@ -297,6 +306,7 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "BA",
       "location": null,
       "nuts2": "",
@@ -306,6 +316,7 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "PL",
       "location": null,
       "nuts2": "",
@@ -315,6 +326,7 @@ Object {
     },
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "UK",
       "location": null,
       "nuts2": "",

--- a/services/ingestion/etl/inforegio/json/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/json/src/lib/transform.js
@@ -8,7 +8,7 @@ import type { Project } from '../../../../types/Project';
 
 const getFundingArea = record =>
   // Get value for 'Funding area' if property is present.
-  (record.Funds ? record.Funds.split(';') : []).filter(
+  (record.Funds ? record.Funds.split(';').filter(fund => fund) : []).filter(
     // Remove empty strings.
     item => item
   );
@@ -103,7 +103,7 @@ export default (record: Object): Project => {
   // Preprocess project locations
   const locationArray = [];
   const countryArray = record.Project_country
-    ? record.Project_country.split('; ')
+    ? record.Project_country.split('; ').filter(country => country)
     : null;
   const previousCountries = [];
   if (countryArray !== null && countryArray.length > 1) {
@@ -117,6 +117,7 @@ export default (record: Object): Project => {
           postal_code: '',
           town: '',
           location: null,
+          centroid: null,
         });
         previousCountries.push(countryArray[i]);
       }
@@ -130,6 +131,7 @@ export default (record: Object): Project => {
       postal_code: '',
       town: '',
       location: null,
+      centroid: null,
     });
   }
 

--- a/services/ingestion/etl/inforegio/json/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/json/src/lib/transform.js
@@ -8,10 +8,7 @@ import type { Project } from '../../../../types/Project';
 
 const getFundingArea = record =>
   // Get value for 'Funding area' if property is present.
-  (record.Funds ? record.Funds.split(';').filter(fund => fund) : []).filter(
-    // Remove empty strings.
-    item => item
-  );
+  record.Funds ? record.Funds.split(';').filter(fund => fund) : [];
 
 // Formats date from DD/MM/YYYY to ISO 8601 date format.
 const formatDate = date => {

--- a/services/ingestion/etl/inforegio/json/test/unit/lib/__snapshots__/transform.spec.js.snap
+++ b/services/ingestion/etl/inforegio/json/test/unit/lib/__snapshots__/transform.spec.js.snap
@@ -58,6 +58,7 @@ Object {
   "project_locations": Array [
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "HU",
       "location": null,
       "nuts2": "HU10",

--- a/services/ingestion/etl/inforegio/xml/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/xml/src/lib/transform.js
@@ -90,6 +90,7 @@ export default (record: Object): Project => {
     ? checkData(record.Project_country)
         .toString()
         .split('; ')
+        .filter(country => country)
     : null;
   const previousCountries = [];
   if (countryArray !== null && countryArray.length > 1) {
@@ -103,6 +104,7 @@ export default (record: Object): Project => {
           postal_code: '',
           town: '',
           location: null,
+          centroid: null,
         });
         previousCountries.push(countryArray[i]);
       }
@@ -116,6 +118,7 @@ export default (record: Object): Project => {
       postal_code: '',
       town: '',
       location: null,
+      centroid: null,
     });
   }
 
@@ -127,6 +130,7 @@ export default (record: Object): Project => {
     ? checkData(record.Themes)
         .toString()
         .split('; ')
+        .filter(theme => theme)
     : [];
 
   // Preprocess partners

--- a/services/ingestion/etl/inforegio/xml/test/unit/lib/__snapshots__/transform.spec.js.snap
+++ b/services/ingestion/etl/inforegio/xml/test/unit/lib/__snapshots__/transform.spec.js.snap
@@ -47,6 +47,7 @@ Object {
   "project_locations": Array [
     Object {
       "address": "",
+      "centroid": null,
       "country_code": "EL",
       "location": null,
       "nuts2": "EL0",

--- a/services/ingestion/etl/types/Project.js
+++ b/services/ingestion/etl/types/Project.js
@@ -58,7 +58,7 @@ type Budget = {
 
 type Coordinates = {
   lat: number,
-  long: number,
+  lon: number,
 };
 
 type Coordinator = {

--- a/services/ingestion/etl/types/Project.js
+++ b/services/ingestion/etl/types/Project.js
@@ -56,6 +56,11 @@ type Budget = {
   total_cost: BudgetItem,
 };
 
+type Coordinates = {
+  lat: number,
+  long: number,
+};
+
 type Coordinator = {
   address: string,
   country: string,
@@ -69,6 +74,7 @@ type Coordinator = {
 
 type Location = {
   address: string,
+  centroid: Coordinates | null,
   country_code: string,
   // If nothing else, provide null in transform function for this field.
   // Never null project_locations field which is typed on ES level.


### PR DESCRIPTION
Note: it fixes EUBFR-129 too

You can test:

POST https://search-dev-projects-x2q4chklpgav5gdxfcuihuox5i.eu-central-1.es.amazonaws.com/hupr82-projects/project/_search

```json
{
    "query": {
        "bool" : {
            "must" : {
                "match_all" : {}
            },
            "filter" : {
                "geo_bounding_box" : {
                    "project_locations.centroid" : {
                        "top_left" : {
                            "lat" : 53.0,
                            "lon" : 13.0
                        },
                        "bottom_right" : {
                            "lat" : 52.0,
                            "lon" : 14.0
                        }
                    }
                }
            }
        }
    }
}
```

Interestingly, it returns more results (1 more) than:

POST https://search-dev-projects-x2q4chklpgav5gdxfcuihuox5i.eu-central-1.es.amazonaws.com/hupr82-projects/project/_search

```json
{
    "query": {
        "bool" : {
            "must" : {
                "match_all" : {}
            },
            "filter" : {
                "geo_shape" : {
                    "project_locations.location" : {
                        "shape": {
                            "type": "envelope",
                            "coordinates" : [[13.0, 53.0], [14.0, 52.0]]
                        },
                        "relation": "within"
                    }
                }
            }
        }
    }
}
```

Any idea why?