### PR TITLE
feat(es-id): provide ES IDs for projects - EUBFR-125

### DIFF
--- a/services/value-store/projects/src/events/onObjectCreated.js
+++ b/services/value-store/projects/src/events/onObjectCreated.js
@@ -115,7 +115,7 @@ export const handler = async (event, context, callback) => {
           const item = Object.assign(
             {
               computed_key: s3record.s3.object.key,
-              producer_id: s3record.userIdentity.principalId,
+              created_by: s3record.userIdentity.principalId, // which service created the harmonized file
               last_modified: data.LastModified.toISOString(), // ISO-8601 date
             },
             chunk

--- a/services/value-store/projects/src/lib/SaveStream.js
+++ b/services/value-store/projects/src/lib/SaveStream.js
@@ -10,10 +10,15 @@ export default class SaveStream extends stream.Writable {
   }
 
   _write(chunk, enc, next) {
+    // Manually calculate the ID
+    // computed_key + project_id
+    const { computed_key: computedKey, project_id: projectId } = chunk;
+    const id = `${computedKey}/${projectId}`;
     return this.client.index(
       {
         index: this.index,
         type,
+        id,
         body: chunk,
       },
       next

--- a/services/value-store/projects/src/lib/SaveStream.js
+++ b/services/value-store/projects/src/lib/SaveStream.js
@@ -1,4 +1,5 @@
 import stream from 'stream';
+import crypto from 'crypto';
 
 const type = `project`;
 
@@ -11,9 +12,13 @@ export default class SaveStream extends stream.Writable {
 
   _write(chunk, enc, next) {
     // Manually calculate the ID
-    // computed_key + project_id
+    // md5 hash of computed_key + project_id
     const { computed_key: computedKey, project_id: projectId } = chunk;
-    const id = `${computedKey}/${projectId}`;
+    const id = crypto
+      .createHash('md5')
+      .update(`${computedKey}/${projectId}`)
+      .digest('hex');
+
     return this.client.index(
       {
         index: this.index,


### PR DESCRIPTION
The IDs are now an md5 hash of `${computedKey}/${projectId}`