### PR TITLE
fix(delete-scripts): run more tasks in parallel - no issue

### DIFF
--- a/scripts/delete-demo.js
+++ b/scripts/delete-demo.js
@@ -15,21 +15,32 @@ if (process.env.EUBFR_USERNAME) {
   );
 }
 
-// Remove dashboards
-usernames.forEach(async username => {
+const deleteClient = async username => {
   // Delete S3 buckets holding static assets (the React apps)
   await deleteServerlessService('demo-dashboard-client', {
     isClient: true,
     username,
   });
+
   // Delete also the CloudFormation stacks created by SLS
   await deleteServerlessService('demo-dashboard-client', { username });
-  // Lastly, delete their back-ends
-  await deleteServerlessService('demo-dashboard-server', { username });
-});
+};
 
-// Remove the webiste
-(async function removeWebsite() {
+const deleteServer = async username =>
+  deleteServerlessService('demo-dashboard-server', { username });
+
+const deleteWebsite = async () => {
   await deleteServerlessService('demo-website', { isClient: true });
   await deleteServerlessService('demo-website', {});
-})();
+};
+
+// Remove dashboards
+const deleteDemo = async () =>
+  Promise.all([
+    ...usernames.map(async username =>
+      Promise.all([deleteClient(username), deleteServer(username)])
+    ),
+    deleteWebsite(),
+  ]);
+
+deleteDemo();

--- a/scripts/delete-demo.js
+++ b/scripts/delete-demo.js
@@ -34,7 +34,6 @@ const deleteWebsite = async () => {
   await deleteServerlessService('demo-website', {});
 };
 
-// Remove dashboards
 const deleteDemo = async () =>
   Promise.all([
     ...usernames.map(async username =>
@@ -43,4 +42,5 @@ const deleteDemo = async () =>
     deleteWebsite(),
   ]);
 
+// Start
 deleteDemo();

--- a/scripts/delete-resources.js
+++ b/scripts/delete-resources.js
@@ -5,10 +5,12 @@ require(`./utils/protectStage`)();
 // Dependencies
 const deleteServerlessService = require('./utils/deleteServerlessService');
 
-const services = [
+const deleteResources = async resources =>
+  Promise.all(resources.map(deleteServerlessService));
+
+// Start
+deleteResources([
   'resources-raw-storage',
   'resources-harmonized-storage',
   'resources-elasticsearch',
-];
-
-services.forEach(deleteServerlessService);
+]);

--- a/scripts/delete-resources.js
+++ b/scripts/delete-resources.js
@@ -12,5 +12,7 @@ const deleteResources = async resources =>
 deleteResources([
   'resources-raw-storage',
   'resources-harmonized-storage',
-  'resources-elasticsearch',
+  // ES is tied to the environment (dev, test, prod) and should not be deleted with the stage
+  // If you want to remove it, do it manually
+  // 'resources-elasticsearch',
 ]);

--- a/scripts/delete.js
+++ b/scripts/delete.js
@@ -5,7 +5,11 @@ require('./utils/protectStage')();
 // Dependencies
 const deleteServerlessService = require('./utils/deleteServerlessService');
 
-const services = [
+const deleteServices = async services =>
+  Promise.all(services.map(deleteServerlessService));
+
+// Start the deletion
+deleteServices([
   'storage-signed-uploads',
   'storage-deleter',
   'ingestion-manager',
@@ -18,6 +22,4 @@ const services = [
   'value-store-projects',
   'logger-listener',
   'enrichment-manager',
-];
-
-services.forEach(async service => deleteServerlessService(service, {}));
+]);

--- a/scripts/utils/deleteServerlessService.js
+++ b/scripts/utils/deleteServerlessService.js
@@ -15,7 +15,9 @@ const resolveSymbolicLink = filePath => {
 
 module.exports = (service, { isClient = false, username = '' }) =>
   new Promise((resolve, reject) => {
-    const serviceName = `${service}${username ? `-${username}` : ''}`;
+    const serviceName = `${service}${username ? `-${username}` : ''}${
+      isClient ? ' (client)' : ''
+    }`;
     console.log(`Start deletion of ${serviceName}`);
     console.time(serviceName);
 


### PR DESCRIPTION
`yarn delete-demo` now runs everything it can in parallel 😉 

And this patch also fixes issues like `(node:97856) Warning: No such label 'demo-dashboard-client-valor' for console.timeEnd()`