### PR TITLE
fix(iati-etl): use expenditure rather than commitment - EUBFR-162

### DIFF
--- a/scripts/cleaning/delete.js
+++ b/scripts/cleaning/delete.js
@@ -10,8 +10,7 @@ const deleteServices = async services =>
 
 // Start the deletion
 deleteServices([
-  'storage-signed-uploads',
-  'storage-deleter',
+  'enrichment-manager',
   'ingestion-manager',
   'ingestion-cleaner',
   'ingestion-etl-agri-csv',
@@ -23,5 +22,6 @@ deleteServices([
   'ingestion-etl-wifi4eu-xls',
   'value-store-projects',
   'logger-listener',
-  'enrichment-manager',
+  'storage-signed-uploads',
+  'storage-deleter',
 ]);

--- a/services/ingestion/etl/iati/csv/src/lib/transform.js
+++ b/services/ingestion/etl/iati/csv/src/lib/transform.js
@@ -25,7 +25,7 @@ import type { Project } from '../../../../_types/Project';
  */
 const getBudget = record => {
   const currency = record.currency || '';
-  const raw = record['total-Commitment'] || '';
+  const raw = record['total-Expenditure'] || '';
 
   return {
     eu_contrib: {

--- a/services/ingestion/etl/iati/csv/test/stubs/record.json
+++ b/services/ingestion/etl/iati/csv/test/stubs/record.json
@@ -54,7 +54,7 @@
   "currency": "EUR",
   "total-Commitment": "0",
   "total-Disbursement": "319800.89",
-  "total-Expenditure": "0",
+  "total-Expenditure": "395640",
   "total-Incoming Funds": "0",
   "total-Interest Repayment": "0",
   "total-Loan Repayment": "0",

--- a/services/ingestion/etl/iati/csv/test/unit/lib/__snapshots__/transform.spec.js.snap
+++ b/services/ingestion/etl/iati/csv/test/unit/lib/__snapshots__/transform.spec.js.snap
@@ -6,7 +6,7 @@ Object {
   "budget": Object {
     "eu_contrib": Object {
       "currency": "EUR",
-      "raw": "0",
+      "raw": "395640",
       "value": 0,
     },
     "funding_area": Array [],


### PR DESCRIPTION
# PR description

This is changing the field containing the information about `eu_contrib` from `total-Commitment` to `total-Expenditure`, since the first one rarely contains value compared to the second one. This change should give better information about the total budget spent in analytics.

Test environment (the before effect): https://search-test-public-ip4o6f4o6ziykrbjm4kdpyosfu.eu-central-1.es.amazonaws.com/test-projects/_search

In test, you can use a query like this in order to filter projects only from IATI producer:

```
{
    "query" : {
        "term" : { "computed_key" : "iati/09b297e2-e18c-4964-b6cd-c0cc65b7725f.csv.ndjson" }
    }
}
```

Dev environment (the after effect): https://search-dev-public-g7cnsnvyupyfaccjhtcdr23jai.eu-central-1.es.amazonaws.com/chernka162-projects/_search

## QA Checklist

When you add a new ETL/producer, please check for the following:

* [ ] Producer's secrets are stored safely
* [ ] Ensure the ETL is added to the corresponding `scripts/` for automated deployment and deletion 
* [ ] There is at least 1 unit test with a jest snapshot for the transform function of the ETL
* [ ] Update the file PRODUCERS_DATA_AVAILABILITY_GRID.md indicating which fields are available in source data of ETL
* [ ] Ensure there is (flow/jsdocs) documentation in the `tranform.js` file which is to be used for automated documentation
* [ ] Generate the necessary documentation pages for the new ETL by `yarn docs:md`
