### PR TITLE
fix(iati-etl): change value for budget as well - EUBFR-162

### DIFF
--- a/services/ingestion/etl/iati/csv/src/lib/transform.js
+++ b/services/ingestion/etl/iati/csv/src/lib/transform.js
@@ -26,10 +26,11 @@ import type { Project } from '../../../../_types/Project';
 const getBudget = record => {
   const currency = record.currency || '';
   const raw = record['total-Expenditure'] || '';
+  const value = Number(record['total-Expenditure']) || 0;
 
   return {
     eu_contrib: {
-      value: 0,
+      value,
       currency,
       raw,
     },

--- a/services/ingestion/etl/iati/csv/test/unit/lib/__snapshots__/transform.spec.js.snap
+++ b/services/ingestion/etl/iati/csv/test/unit/lib/__snapshots__/transform.spec.js.snap
@@ -7,7 +7,7 @@ Object {
     "eu_contrib": Object {
       "currency": "EUR",
       "raw": "395640",
-      "value": 0,
+      "value": 395640,
     },
     "funding_area": Array [],
     "mmf_heading": "",


### PR DESCRIPTION
# PR description

Only when I re-deployed and re-uploaded data, I saw the visual is taking `Sum of budget.eu_contrib.value`, sorry ...

## QA Checklist

When you add a new ETL/producer, please check for the following:

* [ ] Producer's secrets are stored safely
* [ ] Ensure the ETL is added to the corresponding `scripts/` for automated deployment and deletion 
* [ ] There is at least 1 unit test with a jest snapshot for the transform function of the ETL
* [ ] Update the file PRODUCERS_DATA_AVAILABILITY_GRID.md indicating which fields are available in source data of ETL
* [ ] Ensure there is (flow/jsdocs) documentation in the `tranform.js` file which is to be used for automated documentation
* [ ] Generate the necessary documentation pages for the new ETL by `yarn docs:md`
