### PR TITLE
fix(etl): update transform function inforegio - EUBFR-208

### DIFF
--- a/lib/budgetFormatter.js
+++ b/lib/budgetFormatter.js
@@ -36,6 +36,24 @@ const fixedRates = {
 export const sanitizeValue = value => {
   if (!value) return 0;
 
+  numeral.locale() !== 'eubfr' &&
+    numeral.register('locale', 'eubfr', {
+      delimiters: {
+        thousands: [' ', '.'],
+        decimal: ',',
+      },
+      abbreviations: {
+        thousand: 'k',
+        million: 'm',
+        billion: 'b',
+        trillion: 't',
+      },
+      currency: {
+        symbol: '€',
+      },
+    }) &&
+    numeral.locale('eubfr');
+
   const sanitizedValue = Math.abs(numeral(value).value()) || 0;
 
   // Prevent long values

--- a/lib/budgetFormatter.js
+++ b/lib/budgetFormatter.js
@@ -36,25 +36,6 @@ const fixedRates = {
 export const sanitizeValue = value => {
   if (!value) return 0;
 
-  if (numeral.locale() !== 'eubfr') {
-    numeral.register('locale', 'eubfr', {
-      delimiters: {
-        thousands: [' ', '.'],
-        decimal: ',',
-      },
-      abbreviations: {
-        thousand: 'k',
-        million: 'm',
-        billion: 'b',
-        trillion: 't',
-      },
-      currency: {
-        symbol: '€',
-      },
-    });
-    numeral.locale('eubfr');
-  }
-
   const sanitizedValue = Math.abs(numeral(value).value()) || 0;
 
   // Prevent long values

--- a/lib/budgetFormatter.js
+++ b/lib/budgetFormatter.js
@@ -36,7 +36,7 @@ const fixedRates = {
 export const sanitizeValue = value => {
   if (!value) return 0;
 
-  numeral.locale() !== 'eubfr' &&
+  if (numeral.locale() !== 'eubfr') {
     numeral.register('locale', 'eubfr', {
       delimiters: {
         thousands: [' ', '.'],
@@ -51,8 +51,9 @@ export const sanitizeValue = value => {
       currency: {
         symbol: '€',
       },
-    }) &&
+    });
     numeral.locale('eubfr');
+  }
 
   const sanitizedValue = Math.abs(numeral(value).value()) || 0;
 

--- a/services/ingestion/etl/inforegio/json/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/json/src/lib/transform.js
@@ -204,10 +204,11 @@ const formatBudget = budget => {
   const currency = budget.split(' ')[0];
 
   const formattedBudget = amount => {
-    if (amount.indexOf('(') >= 0) {
-      amount = amount.split('(').shift();
-    }
-    return amount.replace(/\beur[a-zA-Z]*\b/gi, '').replace(/\s+/g, '');
+    /*eslint no-useless-escape: 0*/
+    /*eslint spaced-comment: 0*/
+    const regex = /(?:\beur\w*|€)\s*([0-9][0-9\., ]*)\s*(million)?|([0-9][0-9\., ]*)\s*(million)?\s*(?:\beur\w*|€)/gi;
+    const matches = amount.match(regex);
+    return matches ? matches[0].replace(/\beur[a-zA-Z]*\b/gi, '').trim() : 0;
   };
 
   return sanitizeBudgetItem({

--- a/services/ingestion/etl/inforegio/json/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/json/src/lib/transform.js
@@ -212,6 +212,7 @@ const formatBudget = budget => {
       ? matches[0]
           .replace(/\beur[a-z]*\b/gi, '')
           .replace(/\bmillion[a-z]*\b/gi, 'm')
+          .replace(/\.(?=[0-9]{3})/g, ',')
           .trim()
       : 0;
   };

--- a/services/ingestion/etl/inforegio/json/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/json/src/lib/transform.js
@@ -213,6 +213,7 @@ const formatBudget = budget => {
           .replace(/\beur[a-z]*\b/gi, '')
           .replace(/\bmillion[a-z]*\b/gi, 'm')
           .replace(/\.(?=[0-9]{3})/g, ',')
+          .replace(/^([^,]*),(?=\d{1,2}(?!\d))(?!.*,)/g, '$1.')
           .trim()
       : 0;
   };

--- a/services/ingestion/etl/inforegio/json/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/json/src/lib/transform.js
@@ -208,7 +208,12 @@ const formatBudget = budget => {
     /*eslint spaced-comment: 0*/
     const regex = /(?:\beur\w*|€)\s*([0-9][0-9\., ]*)\s*(million)?|([0-9][0-9\., ]*)\s*(million)?\s*(?:\beur\w*|€)/gi;
     const matches = amount.match(regex);
-    return matches ? matches[0].replace(/\beur[a-zA-Z]*\b/gi, '').trim() : 0;
+    return matches
+      ? matches[0]
+          .replace(/\beur[a-z]*\b/gi, '')
+          .replace(/\bmillion[a-z]*\b/gi, 'm')
+          .trim()
+      : 0;
   };
 
   return sanitizeBudgetItem({

--- a/services/ingestion/etl/inforegio/json/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/json/src/lib/transform.js
@@ -203,13 +203,15 @@ const formatBudget = budget => {
 
   const currency = budget.split(' ')[0];
 
-  const formattedBudget = budget
-    .split(' ')
-    .slice(1)
-    .join('');
+  const formattedBudget = amount => {
+    if (amount.indexOf('(') >= 0) {
+      amount = amount.split('(').shift();
+    }
+    return amount.replace(/\beur[a-zA-Z]*\b/gi, '').replace(/\s+/g, '');
+  };
 
   return sanitizeBudgetItem({
-    value: formattedBudget,
+    value: formattedBudget(budget),
     currency,
     raw: budget,
   });

--- a/services/ingestion/etl/inforegio/json/test/unit/lib/__snapshots__/transform.spec.js.snap
+++ b/services/ingestion/etl/inforegio/json/test/unit/lib/__snapshots__/transform.spec.js.snap
@@ -5,9 +5,9 @@ Object {
   "action": "",
   "budget": Object {
     "eu_contrib": Object {
-      "currency": "EUR",
+      "currency": "",
       "raw": "ECU 909 553",
-      "value": 909553,
+      "value": 0,
     },
     "funding_area": Array [
       "European Regional Development Fund",
@@ -29,9 +29,9 @@ Object {
       "value": 0,
     },
     "total_cost": Object {
-      "currency": "EUR",
+      "currency": "",
       "raw": "ECU 1 259 101",
-      "value": 1259101,
+      "value": 0,
     },
   },
   "call_year": "",

--- a/services/ingestion/etl/inforegio/xml/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/xml/src/lib/transform.js
@@ -97,13 +97,15 @@ const formatBudget = budget => {
 
   const currency = budget.split(' ')[0];
 
-  const formattedBudget = budget
-    .split(' ')
-    .slice(1)
-    .join('');
+  const formattedBudget = amount => {
+    if (amount.indexOf('(') >= 0) {
+      amount = amount.split('(').shift();
+    }
+    return amount.replace(/\beur[a-zA-Z]*\b/gi, '').replace(/\s+/g, '');
+  };
 
   return sanitizeBudgetItem({
-    value: formattedBudget,
+    value: formattedBudget(budget),
     currency,
     raw: budget,
   });

--- a/services/ingestion/etl/inforegio/xml/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/xml/src/lib/transform.js
@@ -98,10 +98,11 @@ const formatBudget = budget => {
   const currency = budget.split(' ')[0];
 
   const formattedBudget = amount => {
-    if (amount.indexOf('(') >= 0) {
-      amount = amount.split('(').shift();
-    }
-    return amount.replace(/\beur[a-zA-Z]*\b/gi, '').replace(/\s+/g, '');
+    /*eslint no-useless-escape: 0*/
+    /*eslint spaced-comment: 0*/
+    const regex = /(?:\beur\w*|€)\s*([0-9][0-9\., ]*)\s*(million)?|([0-9][0-9\., ]*)\s*(million)?\s*(?:\beur\w*|€)/gi;
+    const matches = amount.match(regex);
+    return matches ? matches[0].replace(/\beur[a-zA-Z]*\b/gi, '').trim() : 0;
   };
 
   return sanitizeBudgetItem({

--- a/services/ingestion/etl/inforegio/xml/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/xml/src/lib/transform.js
@@ -102,7 +102,12 @@ const formatBudget = budget => {
     /*eslint spaced-comment: 0*/
     const regex = /(?:\beur\w*|€)\s*([0-9][0-9\., ]*)\s*(million)?|([0-9][0-9\., ]*)\s*(million)?\s*(?:\beur\w*|€)/gi;
     const matches = amount.match(regex);
-    return matches ? matches[0].replace(/\beur[a-zA-Z]*\b/gi, '').trim() : 0;
+    return matches
+      ? matches[0]
+          .replace(/\beur[a-z]*\b/gi, '')
+          .replace(/\bmillion[a-z]*\b/gi, 'm')
+          .trim()
+      : 0;
   };
 
   return sanitizeBudgetItem({

--- a/services/ingestion/etl/inforegio/xml/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/xml/src/lib/transform.js
@@ -106,6 +106,7 @@ const formatBudget = budget => {
       ? matches[0]
           .replace(/\beur[a-z]*\b/gi, '')
           .replace(/\bmillion[a-z]*\b/gi, 'm')
+          .replace(/\.(?=[0-9]{3})/g, ',')
           .trim()
       : 0;
   };

--- a/services/ingestion/etl/inforegio/xml/src/lib/transform.js
+++ b/services/ingestion/etl/inforegio/xml/src/lib/transform.js
@@ -107,6 +107,7 @@ const formatBudget = budget => {
           .replace(/\beur[a-z]*\b/gi, '')
           .replace(/\bmillion[a-z]*\b/gi, 'm')
           .replace(/\.(?=[0-9]{3})/g, ',')
+          .replace(/^([^,]*),(?=\d{1,2}(?!\d))(?!.*,)/g, '$1.')
           .trim()
       : 0;
   };

--- a/services/ingestion/etl/inforegio/xml/test/unit/lib/__snapshots__/transform.spec.js.snap
+++ b/services/ingestion/etl/inforegio/xml/test/unit/lib/__snapshots__/transform.spec.js.snap
@@ -27,9 +27,9 @@ Object {
       "value": 0,
     },
     "total_cost": Object {
-      "currency": "",
+      "currency": "FEDER",
       "raw": "FEDER (Objectif 5b 1994-1996) 60 979 euros (400 000 FRF)",
-      "value": 0,
+      "value": 60979,
     },
   },
   "call_year": "",


### PR DESCRIPTION
# PR description

The updated transform function should treat all cases except situations like:
`"raw": "£ 84,722"`, 
`"raw": "35 800 000"`, 
~~"raw": "EUR 1.200.000"~~, 
`"raw": "ERDF contribution: 65%"`,
`"raw": "DM 2 400 000 "`,
~~"raw": "EUR 2 013 392,5"~~

Test: http://eubfr-radu208-demo-dashboard-client-inforegio.s3-website.eu-central-1.amazonaws.com/#/files

Query:
```json
{
	"size": 3000,
	"sort": [
		{
			"budget.eu_contrib.value": {
				"order": "asc"
			}
		}
	],
	"query": {
		"constant_score": {
			"filter": {
				"match": {
					"producer_id": "inforegio"
				}
			}
		}
	},
	"aggs": {
		"TT": {
			"sum": {
				"field": "budget.eu_contrib.value"
			}
		}
	}
}
```

## QA Checklist

When you add a new ETL/producer, please check for the following:

* [ ] Producer's secrets are stored safely
* [ ] Ensure the ETL is added to the corresponding `scripts/` for automated deployment and deletion 
* [ ] There is at least 1 unit test with a jest snapshot for the transform function of the ETL
* [ ] Update the file PRODUCERS_DATA_AVAILABILITY_GRID.md indicating which fields are available in source data of ETL
* [ ] Ensure there is (flow/jsdocs) documentation in the `tranform.js` file which is to be used for automated documentation
* [ ] Generate the necessary documentation pages for the new ETL by `yarn docs:md`
