### PR TITLE
refactor(etl): update CORDIS producer to cover FP1 to FP7 on top of H2020

### DIFF
--- a/docs/types/etls/cordis-csv.md
+++ b/docs/types/etls/cordis-csv.md
@@ -114,8 +114,8 @@ output => '2018-12-31T00:00:00.000Z';
 ```
 
 ```javascript
-input => '31/03/1988';
-output => '2018-12-31T00:00:00.000Z';
+input => '01/01/1986';
+output => '1986-01-01T00:00:00.000Z';
 ```
 
 Returns **[Date][7]** The date formatted into an ISO 8601 date format

--- a/docs/types/etls/cordis-csv.md
+++ b/docs/types/etls/cordis-csv.md
@@ -10,7 +10,7 @@ Transform function: [implementation details][2]
 
 **Parameters**
 
--   `record` **[Object][3]** Piece of data to transform before going to harmonized storage.
+- `record` **[Object][3]** Piece of data to transform before going to harmonized storage.
 
 Returns **Project** JSON matching the type fields.
 
@@ -19,13 +19,13 @@ Returns **Project** JSON matching the type fields.
 Preprocess `funding_area`
 Input fields taken from the `record` are:
 
--   `fundingScheme`
+- `fundingScheme`
 
 **Parameters**
 
--   `record` **[Object][3]** The row received from parsed file
+- `record` **[Object][3]** The row received from parsed file
 
-Returns **[Array][4]** 
+Returns **[Array][4]**
 
 ### getBudget
 
@@ -33,9 +33,9 @@ Preprocess budget
 
 **Parameters**
 
--   `record` **[Object][3]** The row received from parsed file
+- `record` **[Object][3]** The row received from parsed file
 
-Returns **Budget** 
+Returns **Budget**
 
 ### getDescription
 
@@ -43,28 +43,42 @@ Preprocess description
 Concatenation of several fields as requested in [https://webgate.ec.europa.eu/CITnet/jira/browse/EUBFR-200?focusedCommentId=2808845&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2808845][5]
 Input fields taken from the `record` are:
 
--   `acronym`
--   `objective`
--   `rcn`
--   `topic`
+- `acronym`
+- `objective`
+- `rcn`
+- `topic`
 
 **Parameters**
 
--   `record` **[Object][3]** The row received from parsed file
+- `record` **[Object][3]** The row received from parsed file
 
-Returns **[String][6]** 
+Returns **[String][6]**
+
+### getProjectId
+
+Preprocess `project_id`
+Seeks for values in the following precedence:
+
+- `id`
+- `reference`
+
+**Parameters**
+
+- `record` **[Object][3]** The row received from parsed file
+
+Returns **[String][6]**
 
 ### getLocations
 
 Preprocess project_locations
 Input fields taken from the `record` are:
 
--   `participants`
--   `participantCountries`
+- `participants`
+- `participantCountries`
 
 **Parameters**
 
--   `record` **[Object][3]** The row received from parsed file
+- `record` **[Object][3]** The row received from parsed file
 
 Returns **[Array][4]** List of {Location} objects for `project_locations` field
 
@@ -73,14 +87,14 @@ Returns **[Array][4]** List of {Location} objects for `project_locations` field
 Preprocess third parties
 Input fields taken from the `record` are:
 
--   `coordinator`
--   `coordinatorCountry`
--   `participants`
--   `participantCountries`
+- `coordinator`
+- `coordinatorCountry`
+- `participants`
+- `participantCountries`
 
 **Parameters**
 
--   `record` **[Object][3]** The row received from parsed file
+- `record` **[Object][3]** The row received from parsed file
 
 Returns **[Array][4]** List of {ThirdParty} objects
 
@@ -90,27 +104,26 @@ Format date
 
 **Parameters**
 
--   `date` **[Date][7]** Date in `YYYY-MM-DD` (ISO) format
+- `date` **[Date][7]** Date in `YYYY-MM-DD` or `DD/MM/YYYY` formats.
 
 **Examples**
 
 ```javascript
-input => "2018-12-31"
-output => "2018-12-31T00:00:00.000Z"
+input => '2018-12-31';
+output => '2018-12-31T00:00:00.000Z';
+```
+
+```javascript
+input => '31/03/1988';
+output => '2018-12-31T00:00:00.000Z';
 ```
 
 Returns **[Date][7]** The date formatted into an ISO 8601 date format
 
 [1]: https://github.com/ec-europa/eubfr-data-lake/blob/master/services/ingestion/etl/cordis/csv/test/stubs/record.json
-
 [2]: https://github.com/ec-europa/eubfr-data-lake/blob/master/services/ingestion/etl/cordis/csv/src/lib/transform.js
-
 [3]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
-
 [4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
-
 [5]: https://webgate.ec.europa.eu/CITnet/jira/browse/EUBFR-200?focusedCommentId=2808845&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2808845
-
 [6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
-
 [7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date

--- a/services/ingestion/etl/cordis/csv/README.md
+++ b/services/ingestion/etl/cordis/csv/README.md
@@ -5,7 +5,7 @@ Model to compare with is available at: https://ec-europa.github.io/eubfr-data-la
 | Field                | Target                |
 | -------------------- | --------------------- |
 | rcn                  | description           |
-| id                   | project_id            |
+| id, reference        | project_id            |
 | acronym              | description           |
 | status               | status                |
 | programme            | sub_programme_name    |

--- a/services/ingestion/etl/cordis/csv/src/lib/transform.js
+++ b/services/ingestion/etl/cordis/csv/src/lib/transform.js
@@ -218,8 +218,8 @@ const getThirdParties = record => {
  * output => "2018-12-31T00:00:00.000Z"
  *
  * @example
- * input => "31/03/1988"
- * output => "2018-12-31T00:00:00.000Z"
+ * input => "01/01/1986"
+ * output => '1986-01-01T00:00:00.000Z'
  */
 const formatDate = date => {
   if (!date || typeof date !== 'string') return null;

--- a/services/ingestion/etl/cordis/csv/src/lib/transform.js
+++ b/services/ingestion/etl/cordis/csv/src/lib/transform.js
@@ -237,12 +237,10 @@ const formatDate = date => {
     }
   }
   // Case `YYYY-MM-DD`:
-  else {
-    try {
-      return new Date(date).toISOString();
-    } catch (e) {
-      return null;
-    }
+  try {
+    return new Date(date).toISOString();
+  } catch (e) {
+    return null;
   }
 };
 

--- a/services/ingestion/etl/cordis/csv/test/stubs/recordReference.json
+++ b/services/ingestion/etl/cordis/csv/test/stubs/recordReference.json
@@ -1,0 +1,25 @@
+{
+  "rcn": "14088",
+  "reference": "EN3M0034",
+  "acronym": "",
+  "status": "",
+  "programme": "FP1-ENNONUC 3C",
+  "topics": "",
+  "frameworkProgramme": "FP1",
+  "title":
+    "Energy and environment - Optimal control strategies for reducing emissions from energy production and energy use",
+  "startDate": "01/01/1986",
+  "endDate": "31/03/1988",
+  "projectUrl": "",
+  "objective":
+    "As a result of the rapid increase in forest damages in Mid-Europe, the need for the reduction of air pollutions from energy conversion and energy-end-use technologies became an important political objective.",
+  "totalCost": "",
+  "ecMaxContribution": "",
+  "call": "",
+  "fundingScheme": "CSC",
+  "coordinator": "UNIVERSITAET KARLSRUHE (TECHNISCHE HOCHSCHULE)",
+  "coordinatorCountry": "DE",
+  "participants": "FORSCHUNGSZENTRUM JUELICH GMBH;UNIVERSITAET STUTTGART",
+  "participantCountries": "DE",
+  "subjects": ""
+}

--- a/services/ingestion/etl/cordis/csv/test/unit/lib/__snapshots__/transform.spec.js.snap
+++ b/services/ingestion/etl/cordis/csv/test/unit/lib/__snapshots__/transform.spec.js.snap
@@ -416,6 +416,116 @@ objective: The overarching objective of UNISECO is to strengthen the sustainabil
 }
 `;
 
+exports[`DG CORDIS CSV transformer Can handle records which contain project_id in field called reference instead of an id 1`] = `
+Object {
+  "action": "",
+  "budget": Object {
+    "eu_contrib": Object {
+      "currency": "",
+      "raw": "",
+      "value": 0,
+    },
+    "funding_area": Array [
+      "CSC",
+    ],
+    "mmf_heading": "",
+    "other_contrib": Object {
+      "currency": "",
+      "raw": "",
+      "value": 0,
+    },
+    "private_fund": Object {
+      "currency": "",
+      "raw": "",
+      "value": 0,
+    },
+    "public_fund": Object {
+      "currency": "",
+      "raw": "",
+      "value": 0,
+    },
+    "total_cost": Object {
+      "currency": "",
+      "raw": "",
+      "value": 0,
+    },
+  },
+  "call_year": "",
+  "complete": true,
+  "description": "rcn: 14088
+objective: As a result of the rapid increase in forest damages in Mid-Europe, the need for the reduction of air pollutions from energy conversion and energy-end-use technologies became an important political objective.",
+  "ec_priorities": Array [],
+  "media": Array [],
+  "programme_name": "FP1",
+  "project_id": "EN3M0034",
+  "project_locations": Array [
+    Object {
+      "address": "",
+      "centroid": null,
+      "country_code": "DE",
+      "location": null,
+      "nuts": Array [],
+      "postal_code": "",
+      "region": "",
+      "town": "",
+    },
+  ],
+  "project_website": "",
+  "related_links": Array [],
+  "reporting_organisation": "RTD",
+  "results": Object {
+    "available": "",
+    "result": "",
+  },
+  "status": "",
+  "sub_programme_name": "FP1-ENNONUC 3C",
+  "success_story": "",
+  "themes": Array [],
+  "third_parties": Array [
+    Object {
+      "address": "",
+      "country": "DE",
+      "email": "",
+      "name": "UNIVERSITAET KARLSRUHE (TECHNISCHE HOCHSCHULE)",
+      "phone": "",
+      "region": "",
+      "role": "coordinator",
+      "type": "",
+      "website": "",
+    },
+    Object {
+      "address": "",
+      "country": "DE",
+      "email": "",
+      "name": "FORSCHUNGSZENTRUM JUELICH GMBH",
+      "phone": "",
+      "region": "",
+      "role": "participant",
+      "type": "",
+      "website": "",
+    },
+    Object {
+      "address": "",
+      "email": "",
+      "name": "UNIVERSITAET STUTTGART",
+      "phone": "",
+      "region": "",
+      "role": "participant",
+      "type": "",
+      "website": "",
+    },
+  ],
+  "timeframe": Object {
+    "from": "1986-01-01T00:00:00.000Z",
+    "from_precision": "day",
+    "to": "1988-03-31T00:00:00.000Z",
+    "to_precision": "day",
+  },
+  "title": "Energy and environment - Optimal control strategies for reducing emissions from energy production and energy use",
+  "type": Array [],
+}
+`;
+
 exports[`DG CORDIS CSV transformer Produces correct JSON output structure 1`] = `
 Object {
   "action": "",

--- a/services/ingestion/etl/cordis/csv/test/unit/lib/transform.spec.js
+++ b/services/ingestion/etl/cordis/csv/test/unit/lib/transform.spec.js
@@ -5,14 +5,17 @@
 import mapper from '../../../src/lib/transform';
 import testRecord from '../../stubs/record.json';
 import testRecord2 from '../../stubs/record2.json';
+import testRecordReferenceId from '../../stubs/recordReference.json';
 
 describe('DG CORDIS CSV transformer', () => {
   let result = {};
   let resultMultiple = {};
+  let resultReferenceId = {};
 
   beforeAll(() => {
     result = mapper(testRecord);
     resultMultiple = mapper(testRecord2);
+    resultReferenceId = mapper(testRecordReferenceId);
   });
 
   test('Returns null when record is not provided', () => {
@@ -25,5 +28,19 @@ describe('DG CORDIS CSV transformer', () => {
 
   test('Can handle multi-value inputs for participants and coordinators', () => {
     expect(resultMultiple).toMatchSnapshot();
+  });
+
+  test('Can handle records which contain project_id in field called reference instead of an id', () => {
+    // FP before 5 are with `reference`, whereas newer FPs are with `id`.
+    expect(resultReferenceId).toMatchSnapshot();
+  });
+
+  test('Can handle 2 types of dates: `YYYY-MM-DD` and `DD/MM/YYYY`', () => {
+    // Newer FPs are `YYYY-MM-DD`:
+    expect(result.timeframe.from).toEqual('2018-11-01T00:00:00.000Z');
+    // Older FPs are `DD/MM/YYYY`:
+    expect(resultReferenceId.timeframe.from).toEqual(
+      '1986-01-01T00:00:00.000Z'
+    );
   });
 });


### PR DESCRIPTION
# PR description

RTD making use of CORDIS export sharing data to the open data portal.

Differences between existing H2020 projects and framework programmes (FP) 1 to 7 are in dates and id fields. 

## QA Checklist

When you add a new ETL/producer, please check for the following:

* [ ] Producer's secrets are stored safely
* [ ] Ensure the ETL is added to the corresponding `scripts/` for automated deployment and deletion 
* [ ] There is at least 1 unit test with a jest snapshot for the transform function of the ETL
* [ ] Update the file PRODUCERS_DATA_AVAILABILITY_GRID.md indicating which fields are available in source data of ETL
* [ ] Ensure there is (flow/jsdocs) documentation in the `tranform.js` file which is to be used for automated documentation
* [ ] Generate the necessary documentation pages for the new ETL by `yarn docs:md`
