### PR TITLE
chore(release): mark 0.7.0 - noissue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## 0.7.0 (2019-05-14)
+
+#### :rocket: New Feature
+
+- [#211](https://github.com/ec-europa/eubfr-data-lake/pull/211) feat(etls): add interreg 2014TC16M6TN001 - EUBFR-258 ([@kalinchernev](https://github.com/kalinchernev))
+- [#207](https://github.com/ec-europa/eubfr-data-lake/pull/207) feat(etls): add interreg 2014TC16I5CB005 - EUBFR-258 ([@kalinchernev](https://github.com/kalinchernev))
+- [#204](https://github.com/ec-europa/eubfr-data-lake/pull/204) feat(etls): add interreg 2014TC16RFCB047 - EUBFR-258 ([@kalinchernev](https://github.com/kalinchernev))
+- [#203](https://github.com/ec-europa/eubfr-data-lake/pull/203) feat(etls): add interreg 2014TC16RFCB014 - EUBFR-258 ([@kalinchernev](https://github.com/kalinchernev))
+- [#206](https://github.com/ec-europa/eubfr-data-lake/pull/206) feat(etls): add interreg 2014TC16RFTN002 - EUBFR-258 ([@kalinchernev](https://github.com/kalinchernev))
+- [#205](https://github.com/ec-europa/eubfr-data-lake/pull/205) feat(etls): add interreg 2014TC16RFPC001 - EUBFR-258 ([@kalinchernev](https://github.com/kalinchernev))
+- [#201](https://github.com/ec-europa/eubfr-data-lake/pull/201) feat(etls): add producer: bulgaria - EUBFR-257 ([@kalinchernev](https://github.com/kalinchernev))
+- [#202](https://github.com/ec-europa/eubfr-data-lake/pull/202) feat(etls): add interreg 2014TC16M4TN002 - EUBFR-258 ([@kalinchernev](https://github.com/kalinchernev))
+- [#190](https://github.com/ec-europa/eubfr-data-lake/pull/190) feat(eubfr-cli): content download - EUBFR-234 ([@kalinchernev](https://github.com/kalinchernev))
+
+#### :nail_care: Enhancement
+
+- [#199](https://github.com/ec-europa/eubfr-data-lake/pull/199) refactor(etls): toggle complete flag - EUBFR-250 ([@kalinchernev](https://github.com/kalinchernev))
+
+#### :house: Internal
+
+- [#200](https://github.com/ec-europa/eubfr-data-lake/pull/200) chore(deps): upgrades - noissue ([@kalinchernev](https://github.com/kalinchernev))
+
 ## 0.6.0 (2018-12-14)
 
 #### :rocket: New Feature

--- a/demo/dashboard/client/package.json
+++ b/demo/dashboard/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eubfr/demo-dashboard-client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "start": "run-s prepare react:start",
     "build": "npm run prepare && react-scripts build",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@ecl/ec-preset-website": "1.3.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "elasticsearch": "15.4.1",
     "prop-types": "15.7.2",
     "react": "16.8.6",

--- a/demo/dashboard/server/package.json
+++ b/demo/dashboard/server/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@eubfr/demo-dashboard-server",
   "description": "",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "start": "sls offline start"

--- a/demo/website/package.json
+++ b/demo/website/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eubfr/demo-website",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "start": "npm run prepare && react-scripts start",
     "build": "npm run prepare && react-scripts build",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.11.0",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "changelog": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eubfr/lib",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "n/a",
   "scripts": {
     "test:unit": "jest --testPathPattern=unit"

--- a/plugins/serverless-plugin-elasticsearch-index/package.json
+++ b/plugins/serverless-plugin-elasticsearch-index/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "serverless-plugin-elasticsearch-index",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "dependencies": {
     "aws-sdk": "2.434.0",
     "awscred": "1.4.2",

--- a/resources/backup-storage/package.json
+++ b/resources/backup-storage/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eubfr/resources-backup-storage",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v"
   },

--- a/resources/elasticsearch/package.json
+++ b/resources/elasticsearch/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "@eubfr/resources-elasticsearch",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v"
   },
   "devDependencies": {
     "serverless": "1.40.0",
-    "serverless-plugin-elasticsearch-index": "^0.6.0"
+    "serverless-plugin-elasticsearch-index": "^0.7.0"
   }
 }

--- a/resources/harmonized-storage/package.json
+++ b/resources/harmonized-storage/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eubfr/resources-harmonized-storage",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v"
   },

--- a/resources/raw-storage/package.json
+++ b/resources/raw-storage/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eubfr/resources-raw-storage",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v"
   },

--- a/services/compute/ecs/package.json
+++ b/services/compute/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eubfr/compute-ecs",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "dependencies": {
     "aws-sdk": "2.434.0",
     "promisepipe": "3.0.0",

--- a/services/compute/stopper/package.json
+++ b/services/compute/stopper/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@eubfr/compute-stopper",
   "description": "",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v"
   },

--- a/services/enrichment/fields/budget/package.json
+++ b/services/enrichment/fields/budget/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "@eubfr/enrichment-fields-budget",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
     "elasticsearch": "15.4.1",
     "http-aws-es": "6.0.0",
     "lodash.isequal": "4.5.0",
@@ -17,7 +17,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/enrichment/fields/locations/package.json
+++ b/services/enrichment/fields/locations/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "@eubfr/enrichment-fields-locations",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
     "elasticsearch": "15.4.1",
     "http-aws-es": "6.0.0",
     "lodash.isequal": "4.5.0",
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/enrichment/manager/package.json
+++ b/services/enrichment/manager/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eubfr/enrichment-manager",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v"
   },

--- a/services/enrichment/saver/package.json
+++ b/services/enrichment/saver/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eubfr/enrichment-saver",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v"
   },

--- a/services/ingestion/cleaner/package.json
+++ b/services/ingestion/cleaner/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-cleaner",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "aws-sdk-mock": "4.3.1",
     "babel-jest": "24.7.0",

--- a/services/ingestion/dead-letter-queue/package.json
+++ b/services/ingestion/dead-letter-queue/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-dead-letter-queue",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v"
   },
   "dependencies": {
-    "@eubfr/logger-messenger": "^0.6.0"
+    "@eubfr/logger-messenger": "^0.7.0"
   },
   "devDependencies": {
     "@babel/core": "7.4.3",

--- a/services/ingestion/etl/2014tc16i5cb005/csv/package.json
+++ b/services/ingestion/etl/2014tc16i5cb005/csv/package.json
@@ -1,16 +1,16 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-2014tc16i5cb005-csv",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "i18n-iso-countries": "3.7.8",
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "csv-parse": "4.3.4",
+    "i18n-iso-countries": "3.7.8",
     "numeral": "2.0.6",
     "stream-transform": "1.0.8"
   },
@@ -18,7 +18,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/2014tc16m4tn002/xls/package.json
+++ b/services/ingestion/etl/2014tc16m4tn002/xls/package.json
@@ -1,21 +1,21 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-2014tc16m4tn002-xls",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "xlsx": "0.14.2"
   },
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/2014tc16m6tn001/xls/package.json
+++ b/services/ingestion/etl/2014tc16m6tn001/xls/package.json
@@ -1,21 +1,21 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-2014tc16m6tn001-xls",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "xlsx": "0.14.2"
   },
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/2014tc16rfcb014/csv/package.json
+++ b/services/ingestion/etl/2014tc16rfcb014/csv/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-2014tc16rfcb014-csv",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "csv-parse": "4.3.4",
     "numeral": "2.0.6"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/2014tc16rfcb047/xls/package.json
+++ b/services/ingestion/etl/2014tc16rfcb047/xls/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-2014tc16rfcb047-xls",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "i18n-iso-countries": "3.7.8",
     "xlsx": "0.14.2"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/2014tc16rfpc001/xls/package.json
+++ b/services/ingestion/etl/2014tc16rfpc001/xls/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-2014tc16rfpc001-xls",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "numeral": "2.0.6",
     "xlsx": "0.14.2"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/2014tc16rftn002/xls/package.json
+++ b/services/ingestion/etl/2014tc16rftn002/xls/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-2014tc16rftn002-xls",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "i18n-iso-countries": "3.7.8",
     "xlsx": "0.14.2"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/bulgaria/xls/package.json
+++ b/services/ingestion/etl/bulgaria/xls/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-bulgaria-xls",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "numeral": "2.0.6",
     "xlsx": "0.14.2"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/cordis/csv/package.json
+++ b/services/ingestion/etl/cordis/csv/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-cordis-csv",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "csv-parse": "4.3.4",
     "stream-transform": "1.0.8"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/devco/xls/package.json
+++ b/services/ingestion/etl/devco/xls/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-devco-xls",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "i18n-iso-countries": "3.7.8",
     "xlsx": "0.14.2"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/eac/csv/package.json
+++ b/services/ingestion/etl/eac/csv/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-eac-csv",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "csv-parse": "4.3.4",
     "stream-transform": "1.0.8"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/euinvest/csv/package.json
+++ b/services/ingestion/etl/euinvest/csv/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-euinvest-csv",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "csv-parse": "4.3.4",
     "stream-transform": "1.0.8"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/euresults/csv/package.json
+++ b/services/ingestion/etl/euresults/csv/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-euresults-csv",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "csv-parse": "4.3.4",
     "stream-transform": "1.0.8"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/fts/xls/package.json
+++ b/services/ingestion/etl/fts/xls/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-fts-xls",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "i18n-iso-countries": "3.7.8",
     "xlsx": "0.14.2"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/home/xls/package.json
+++ b/services/ingestion/etl/home/xls/package.json
@@ -1,21 +1,21 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-home-xls",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "xlsx": "0.14.2"
   },
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/iati/csv/package.json
+++ b/services/ingestion/etl/iati/csv/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-iati-csv",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "csv-parse": "4.3.4",
     "stream-transform": "1.0.8"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/inforegio/json/package.json
+++ b/services/ingestion/etl/inforegio/json/package.json
@@ -1,20 +1,20 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-inforegio-json",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0"
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0"
   },
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/inforegio/xml/package.json
+++ b/services/ingestion/etl/inforegio/xml/package.json
@@ -1,21 +1,21 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-inforegio-xml",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "xml2js": "0.4.19"
   },
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/just/csv/package.json
+++ b/services/ingestion/etl/just/csv/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-just-csv",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "csv-parse": "4.3.4",
     "stream-transform": "1.0.8"
   },
@@ -16,7 +16,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/etl/wifi4eu/xls/package.json
+++ b/services/ingestion/etl/wifi4eu/xls/package.json
@@ -1,21 +1,21 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-etl-wifi4eu-xls",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "xlsx": "0.14.2"
   },
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/manager/package.json
+++ b/services/ingestion/manager/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-manager",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
     "elasticsearch": "15.4.1",
     "http-aws-es": "6.0.0"
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/ingestion/quality-analyzer/package.json
+++ b/services/ingestion/quality-analyzer/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/ingestion-quality-analyzer",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit",
     "test-write": "jest --watch"
   },
   "dependencies": {
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "elasticsearch": "15.4.1",
     "http-aws-es": "6.0.0",
     "split2": "3.1.1"
@@ -17,7 +17,7 @@
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-flow": "7.0.0",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/services/logger/listener/package.json
+++ b/services/logger/listener/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eubfr/logger-listener",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v"
   },

--- a/services/logger/messenger/package.json
+++ b/services/logger/messenger/package.json
@@ -1,9 +1,9 @@
 {
   "private": true,
   "name": "@eubfr/logger-messenger",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "dependencies": {
-    "@eubfr/logger-listener": "^0.6.0"
+    "@eubfr/logger-listener": "^0.7.0"
   },
   "devDependencies": {
     "aws-sdk": "2.434.0"

--- a/services/storage/deleter/package.json
+++ b/services/storage/deleter/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@eubfr/storage-deleter",
   "description": "",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "start": "sls offline start"

--- a/services/storage/signed-uploads/package.json
+++ b/services/storage/signed-uploads/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@eubfr/storage-signed-uploads",
   "description": "",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "start": "sls offline start",
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "aws-sdk-mock": "4.3.1",
     "babel-jest": "24.7.0",

--- a/services/value-store/projects/package.json
+++ b/services/value-store/projects/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@eubfr/value-store-projects",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "deploy": "sls deploy -v",
     "test:unit": "jest --testPathPattern=unit"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
-    "@eubfr/logger-messenger": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
+    "@eubfr/logger-messenger": "^0.7.0",
     "elasticsearch": "15.4.1",
     "http-aws-es": "6.0.0",
     "split2": "3.1.1",
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
-    "@eubfr/types": "^0.6.0",
+    "@eubfr/types": "^0.7.0",
     "aws-sdk": "2.434.0",
     "babel-jest": "24.7.0",
     "babel-loader": "8.0.5",

--- a/tools/eubfr-cli/package.json
+++ b/tools/eubfr-cli/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "@eubfr/cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "bin": {
     "eubfr-cli": "./bin/cli.js"
   },
   "dependencies": {
-    "@eubfr/lib": "^0.6.0",
+    "@eubfr/lib": "^0.7.0",
     "aws-sdk": "2.434.0",
     "aws4": "1.8.0",
     "awscred": "1.4.2",

--- a/types/package.json
+++ b/types/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eubfr/types",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "Project.js",
   "dependencies": {
     "flow-geojson": "2.0.7"


### PR DESCRIPTION
The usual update to latest test to what is in master.

ETLs mentioned in the changelog have been deployed on AWS with their corresponding content.