### PR TITLE
chore(elasticsearch): upgrade to 6.5 - EUBFR-260

### DIFF
--- a/demo/dashboard/client/src/clientFactory/index.js
+++ b/demo/dashboard/client/src/clientFactory/index.js
@@ -1,19 +1,20 @@
 import elasticsearch from 'elasticsearch';
 
 const getClients = () => {
-  const privateApiEndpoint = process.env.REACT_APP_ES_PRIVATE_ENDPOINT;
-
-  const publicApiEndpoint = process.env.REACT_APP_ES_PUBLIC_ENDPOINT;
+  const {
+    REACT_APP_ES_PRIVATE_ENDPOINT: privateApiEndpoint,
+    REACT_APP_ES_PUBLIC_ENDPOINT: publicApiEndpoint,
+  } = process.env;
 
   const privateClient = elasticsearch.Client({
     host: privateApiEndpoint,
-    apiVersion: '6.3',
+    apiVersion: '6.5',
     log: 'warning',
   });
 
   const publicClient = elasticsearch.Client({
     host: publicApiEndpoint,
-    apiVersion: '6.3',
+    apiVersion: '6.5',
     log: 'warning',
   });
 

--- a/demo/dashboard/client/src/pages/files/List.js
+++ b/demo/dashboard/client/src/pages/files/List.js
@@ -29,7 +29,7 @@ class List extends Component {
   componentDidMount() {
     this.esClient = elasticsearch.Client({
       host: privateApiEndpoint,
-      apiVersion: '6.3',
+      apiVersion: '6.5',
       log: 'warning',
     });
 

--- a/demo/website/src/components/ProjectsList.js
+++ b/demo/website/src/components/ProjectsList.js
@@ -23,7 +23,7 @@ class ProjectsList extends Component {
   componentDidMount() {
     this.client = new elasticsearch.Client({
       host: apiEndpoint,
-      apiVersion: '6.3',
+      apiVersion: '6.5',
       log: 'warning',
     });
 

--- a/plugins/serverless-plugin-elasticsearch-index/index.js
+++ b/plugins/serverless-plugin-elasticsearch-index/index.js
@@ -39,7 +39,7 @@ class CreateElasticIndexDeploy {
           const esOptions = {
             index,
             connectionClass,
-            apiVersion: '6.3',
+            apiVersion: '6.5',
             host: `https://${domain}`,
             // this is required when out of a lambda function
             awsConfig: new AWS.Config({

--- a/resources/elasticsearch/serverless.yml
+++ b/resources/elasticsearch/serverless.yml
@@ -43,7 +43,7 @@ resources:
       DeletionPolicy: Retain
       Properties:
         DomainName: ${self:custom.publicDomain}
-        ElasticsearchVersion: '6.3'
+        ElasticsearchVersion: '6.5'
         EBSOptions:
           EBSEnabled: true
           VolumeType: gp2
@@ -83,7 +83,7 @@ resources:
       DeletionPolicy: Retain
       Properties:
         DomainName: ${self:custom.privateDomain}
-        ElasticsearchVersion: '6.3'
+        ElasticsearchVersion: '6.5'
         EBSOptions:
           EBSEnabled: true
           VolumeType: gp2

--- a/services/enrichment/fields/budget/src/events/onEnrichRecordRequested.js
+++ b/services/enrichment/fields/budget/src/events/onEnrichRecordRequested.js
@@ -36,7 +36,7 @@ export const handler = async (event, context) => {
   // Elasticsearch client instantiation
   const client = elasticsearch.Client({
     host: `https://${API}`,
-    apiVersion: '6.3',
+    apiVersion: '6.5',
     connectionClass,
     index: INDEX,
   });

--- a/services/enrichment/fields/locations/src/events/onEnrichRecordRequested.js
+++ b/services/enrichment/fields/locations/src/events/onEnrichRecordRequested.js
@@ -60,7 +60,7 @@ export const handler = async (event, context) => {
   // Elasticsearch client instantiation
   const client = elasticsearch.Client({
     host: `https://${API}`,
-    apiVersion: '6.3',
+    apiVersion: '6.5',
     connectionClass,
     index: INDEX,
   });

--- a/services/enrichment/saver/src/events/onEnrichedRecordQueued.js
+++ b/services/enrichment/saver/src/events/onEnrichedRecordQueued.js
@@ -18,7 +18,7 @@ export const handler = async event => {
 
     const client = elasticsearch.Client({
       host: `https://${API}`,
-      apiVersion: '6.2',
+      apiVersion: '6.5',
       connectionClass,
       index: INDEX,
     });

--- a/services/ingestion/manager/src/events/onObjectCreated.js
+++ b/services/ingestion/manager/src/events/onObjectCreated.js
@@ -91,7 +91,7 @@ export const handler = async (event, context) => {
     // elasticsearch client instantiation
     const client = elasticsearch.Client({
       host: `https://${API}`,
-      apiVersion: '6.3',
+      apiVersion: '6.5',
       connectionClass,
       index: INDEX,
     });

--- a/services/ingestion/manager/src/events/onObjectRemoved.js
+++ b/services/ingestion/manager/src/events/onObjectRemoved.js
@@ -37,7 +37,7 @@ export const handler = async event => {
     // elasticsearch client instantiation
     const client = elasticsearch.Client({
       host: `https://${API}`,
-      apiVersion: '6.3',
+      apiVersion: '6.5',
       connectionClass,
       index: INDEX,
     });

--- a/services/ingestion/quality-analyzer/src/events/onObjectCreated.js
+++ b/services/ingestion/quality-analyzer/src/events/onObjectCreated.js
@@ -38,7 +38,7 @@ export const handler = async (event, context) => {
   // Insantiate clients
   const client = elasticsearch.Client({
     host: `https://${API}`,
-    apiVersion: '6.3',
+    apiVersion: '6.5',
     connectionClass,
     index: INDEX,
   });

--- a/services/ingestion/quality-analyzer/src/events/onObjectRemoved.js
+++ b/services/ingestion/quality-analyzer/src/events/onObjectRemoved.js
@@ -33,7 +33,7 @@ export const handler = async event => {
     // elasticsearch client configuration
     const options = {
       host: `https://${API}`,
-      apiVersion: '6.2',
+      apiVersion: '6.5',
       connectionClass,
       index: INDEX,
     };

--- a/services/logger/listener/src/events/onLogEmitted.js
+++ b/services/logger/listener/src/events/onLogEmitted.js
@@ -29,7 +29,7 @@ export const handler = async event => {
     // elasticsearch client configuration
     const options = {
       host: `https://${API}`,
-      apiVersion: '6.3',
+      apiVersion: '6.5',
       connectionClass,
       index: INDEX,
     };

--- a/services/value-store/projects/src/events/onObjectCreated.js
+++ b/services/value-store/projects/src/events/onObjectCreated.js
@@ -40,7 +40,7 @@ export const handler = async (event, context) => {
   // Insantiate clients
   const client = elasticsearch.Client({
     host: `https://${API}`,
-    apiVersion: '6.3',
+    apiVersion: '6.5',
     connectionClass,
     index: INDEX,
   });

--- a/services/value-store/projects/src/events/onObjectRemoved.js
+++ b/services/value-store/projects/src/events/onObjectRemoved.js
@@ -33,7 +33,7 @@ export const handler = event => {
     // elasticsearch client configuration
     const options = {
       host: `https://${API}`,
-      apiVersion: '6.2',
+      apiVersion: '6.5',
       connectionClass,
       index: INDEX,
     };

--- a/tools/eubfr-cli/commands/content/delete.js
+++ b/tools/eubfr-cli/commands/content/delete.js
@@ -47,7 +47,7 @@ const contentDeleteCommand = ({ files, credentials, endpoints }) => {
   const client = elasticsearch.Client({
     host,
     log: 'warning',
-    apiVersion: '6.3',
+    apiVersion: '6.5',
   });
 
   // Marker to delete all files for all producers

--- a/tools/eubfr-cli/commands/content/show.js
+++ b/tools/eubfr-cli/commands/content/show.js
@@ -21,7 +21,7 @@ const contentShowCommand = async ({ file, producer, endpoints }) => {
   const client = elasticsearch.Client({
     host,
     log: 'warning',
-    apiVersion: '6.3',
+    apiVersion: '6.5',
   });
 
   if (file) {

--- a/tools/eubfr-cli/commands/es/createIndex.js
+++ b/tools/eubfr-cli/commands/es/createIndex.js
@@ -22,7 +22,7 @@ const createIndex = async ({ index, mapping, type, host }) => {
     const esOptions = {
       host,
       connectionClass,
-      apiVersion: '6.3',
+      apiVersion: '6.5',
       awsConfig: new AWS.Config({
         accessKeyId,
         secretAccessKey,

--- a/tools/eubfr-cli/commands/es/deleteIndices.js
+++ b/tools/eubfr-cli/commands/es/deleteIndices.js
@@ -22,7 +22,7 @@ const deleteIndices = async ({ indices, host }) => {
     const esOptions = {
       host,
       connectionClass,
-      apiVersion: '6.3',
+      apiVersion: '6.5',
       awsConfig: new AWS.Config({
         accessKeyId,
         secretAccessKey,

--- a/tools/eubfr-cli/commands/es/showCluster.js
+++ b/tools/eubfr-cli/commands/es/showCluster.js
@@ -23,7 +23,7 @@ const showCluster = async host => {
     const esOptions = {
       host,
       connectionClass,
-      apiVersion: '6.3',
+      apiVersion: '6.5',
       awsConfig: new AWS.Config({
         accessKeyId,
         secretAccessKey,

--- a/tools/eubfr-cli/commands/es/showIndices.js
+++ b/tools/eubfr-cli/commands/es/showIndices.js
@@ -23,7 +23,7 @@ const showIndices = async ({ indices, host }) => {
     const esOptions = {
       host,
       connectionClass,
-      apiVersion: '6.3',
+      apiVersion: '6.5',
       awsConfig: new AWS.Config({
         accessKeyId,
         secretAccessKey,

--- a/tools/eubfr-cli/commands/es/snapshotExec.js
+++ b/tools/eubfr-cli/commands/es/snapshotExec.js
@@ -38,7 +38,7 @@ const snapshotExec = async ({ host, method, params }) => {
     const esOptions = {
       host,
       connectionClass,
-      apiVersion: '6.3',
+      apiVersion: '6.5',
       awsConfig: new AWS.Config({
         accessKeyId,
         secretAccessKey,


### PR DESCRIPTION
# PR description

The AWS web console has been used to upgrade dev indices from 6.3 > 6.4 > 6.5.
No issues while upgrades of service, nor in ingesting data with the new versions.
